### PR TITLE
Filter emojis to avoid having them in our training

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ctranslate2==1.14.0
+emoji=1.2.0
 stanza==1.1.1

--- a/split_train_and_valid.py
+++ b/split_train_and_valid.py
@@ -4,6 +4,7 @@ import sys
 import os
 import argparse
 import random
+import emoji
 
 # Read args
 parser = argparse.ArgumentParser()
@@ -29,7 +30,7 @@ if len(source_data) != len(target_data):
 # Filter out bad data
 html_entities = ['&apos;', '&nbsp;', '&lt;', '&gt;', '&quot;']
 html_tags = ['<a>', '<p>', '<h1>', '<i>']
-naughty_strings = html_entities + html_tags
+naughty_strings = html_entities + html_tags + list(emoji.UNICODE_EMOJI_ENGLISH.keys())
 filtered_source_data = []
 filtered_target_data = []
 for i in range(len(source_data)):


### PR DESCRIPTION
This will add emojis as 'unwanted character' next to HTML tags and entities.
More info: https://github.com/argosopentech/argos-translate/issues/51

Alternatively,
We could strip unwanted-symbols from the lines instead of filtering/removing the lines.
But for now this should do it.