### PR TITLE
Fix a tiny formatting

### DIFF
--- a/overtraining_thresholds.csv
+++ b/overtraining_thresholds.csv
@@ -1,4 +1,4 @@
 From lang, To lang, Threshold, Data, Comment
-en,zh,11000,30271458
-ja,en,50000,46545268
+en,zh,11000,30271458,
+ja,en,50000,46545268,
 en,tr,12500,82840885,Native speaker verified


### PR DESCRIPTION
To be precisely correct, and allow the parsers work correctly,
we need to keep the end-line ","s even if the last field is empty.